### PR TITLE
Replace DB_SLAVE with DB_REPLICA

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -144,7 +144,7 @@ class Hooks {
 
 		$len = strlen($filename);
 
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$res = $dbr->select(
 				'page',
 				array(


### PR DESCRIPTION
DB_SLAVE constant was renamed to DB_REPLICA and deprecated since ~MW 1.28